### PR TITLE
Update p file to proper locate the run.py

### DIFF
--- a/sysproduction/linux/scripts/p
+++ b/sysproduction/linux/scripts/p
@@ -1,2 +1,2 @@
 . ~/.profile
-python3 run.py $1
+python3 $SCRIPT_PATH/run.py $1


### PR DESCRIPTION
Without the added variable, the system cannot find the `run.py` from scrips, unless you are in the scripts folder. This modification also matches with the instructions on the tutorials.